### PR TITLE
Inicio muestra progresión usuario

### DIFF
--- a/global.R
+++ b/global.R
@@ -11,6 +11,8 @@ library(sf)
 library(readxl)
 library(shinyWidgets)
 library(DT)
+library(shinyjs)
+library(htmlwidgets)
 
 N_TOTAL_ESTACIONES <- 147
 # Read data

--- a/server.R
+++ b/server.R
@@ -1,4 +1,4 @@
-   server <- function(input, output, session) {
+server <- function(input, output, session) {
   # Metrovalencia: main map
   output$map <- renderLeaflet({
     leaflet() %>%
@@ -70,10 +70,9 @@
         
         data <- data.frame(c(ptot, pline))
         
-        output$stats <- renderDataTable({
-          
-          datatable(data)
-          
+        observe({
+          Sys.sleep(1)  # Simulando un proceso que toma tiempo
+          updateProgressBar(session, "progress", value = ptot)
         })
         
         station <- estaciones %>% filter(id == station_id)

--- a/ui.R
+++ b/ui.R
@@ -18,18 +18,22 @@ sidebar <- div(
   flexPanel(
     id = "general_stats",
     flex = c(1),
-    img(src = "./img/lines/L1.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L2.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L3.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L4.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L5.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L6.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L7.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L8.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L9.svg", style = "width: 24px; height:24px"),
-    img(src = "./img/lines/L10.svg", style = "width: 24px; height:24px")
+    tags$div(
+      style = "display: flex; flex-direction: column;",
+      img(src = "./img/lines/L1.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L2.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L3.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L4.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L5.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L6.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L7.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L8.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L9.svg", style = "width: 24px; height:24px"),
+      img(src = "./img/lines/L10.svg", style = "width: 24px; height:24px")
+    ),
+    progressBar(id = "progress", value = 0)
   ),
-  dataTableOutput("stats"),
+  
   Separator("Información sobre la estación")
 )
 


### PR DESCRIPTION
He añadido una barra de progreso que se basa el porcentaje de aciertos respecto del total, lo he puesto en ese sitio y así parece de la 1, para ver como queda visualmente, se puede hacer eso con las 10 pero usando obviamente los porcentajes de linea(ya estan implementadas ambas funciones) y añadir en el hueco de debajo la barra de progresión total. Es a modo de ejemplo por empezar por algo.