### PR TITLE
Reforma visual

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -11,6 +11,11 @@ header <- flexPanel(
 )
 
 sidebar <- div(
+  Separator("Información sobre la estación")
+  
+)
+
+sidebar_fake <- div(
   id = "sidebar",
   Separator("Busca la estación"),
   searchInput("text", btnSearch = icon("train-subway"), width = "100%"),
@@ -68,8 +73,8 @@ sidebar <- div(
     progressBar(id = "progress9", value = 0, display_pct = TRUE, status = "success"),
     progressBar(id = "progress10", value = 0, display_pct = TRUE, status = "success")
     )
-  ),
-  Separator("Información sobre la estación")
+  )
+  
 )
 
 footer <- flexPanel(
@@ -86,6 +91,6 @@ ui <- gridPage(
   
   header = header,
   sidebar = sidebar,
-  content = div(id="content", leafletOutput('map', height = "100%")),
+  content = div(id="content", sidebar_fake, leafletOutput('map', height = "100%")),
   footer = footer
 )

--- a/www/style.css
+++ b/www/style.css
@@ -1,9 +1,14 @@
 #sidebar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
   box-sizing: border-box;
   box-shadow: rgba(149, 157, 165, 0.6) 0px 1px 3px;
   padding: 5px;
   margin-left: 5px;
   border-radius: 10px;
+  z-index: 1;
 }
 #top_quakes_inputs {
   height: auto;
@@ -20,6 +25,10 @@
 #map, #content {
   border-radius: 10px;
   margin-right: 10px;
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
 }
 #footer{
   padding-left: 5px;


### PR DESCRIPTION
He ido toqueteando y aprendiendo a usar el css, vi en twitch que pusieron el chat superpuesto para movil y me pareció buea idea, quise cambiar el template del gridPage a "holy-rail" pero dejé el sidebar para la info sobre la estación, añadí z-index para superponer el sidebar atiguo (ahora sidebr fake) al contenedor principal. Quedan cosas por coerregir en el sidebar fake, y opacidad y recolocar pero puede ser una opción interesante